### PR TITLE
chore: Add workflow to sync GitHub labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,19 @@
+# .github/workflows/sync-labels.yml
+name: Sync labels
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - .github/labels.yml
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          prune: true   # smaže labely, co nejsou v YAML


### PR DESCRIPTION
This workflow syncs GitHub labels based on the configuration in .github/labels.yml when changes are pushed to the main branch.