### PR TITLE
Implements device registry and services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ help:
 	@echo "  make hassfest-local                  - spustí hassfest na $(COMPONENT_PATH)"
 	@echo "  make hacs-local                      - HACS validace na $(COMPONENT_PATH)"
 	@echo "  make validate-local                  - hassfest + HACS"
+	@echo "  make check-versions                - zkontroluje správnost verzí"
 	@echo "  make clean                           - smaže cache (pytest/ruff/build)"
 	@echo "  make distclean                       - clean + smaže .venv a .ha-core"
 

--- a/bump-ha.toml
+++ b/bump-ha.toml
@@ -20,3 +20,9 @@ filename = ".github/workflows/ci.yml"
 search = 'pip install homeassistant=={current_version}'
 replace = 'pip install homeassistant=={new_version}'
 no-regex = true
+
+[[tool.bumpversion.files]]
+filename = "custom_components/bakalari/const.py"
+search = 'API_VERSION: Final = "{current_version}"'
+replace = 'API_VERSION: Final = "{new_version}"'
+no-regex = true

--- a/bump-version.toml
+++ b/bump-version.toml
@@ -14,3 +14,8 @@ filename = "pyproject.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
 no-regex = true
+
+[[tool.bumpversion.files]]
+filename = "custom_components/bakalari/const.py"
+search = 'LIB_VERSION: Final = "{current_version}"'
+replace = 'LIB_VERSION: Final = "{new_version}"'

--- a/custom_components/bakalari/__init__.py
+++ b/custom_components/bakalari/__init__.py
@@ -2,47 +2,90 @@
 
 from __future__ import annotations
 
+from homeassistant.components import websocket_api
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+import voluptuous as vol
 
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, MANUFACTURER, MODEL, PLATFORMS
+from .coordinator import BakalariCoordinator
+from .utils import device_ident
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config) -> bool:
     """Set up the Bakalari component."""
-
-    # async def _svc_refresh(call: ServiceCall) -> None:
-    #     for entry_id, data in hass.data.get(DOMAIN, {}).items():
-    #         await data["coordinator"].async_request_refresh()
-
-    # hass.services.async_register(DOMAIN, "refresh", _svc_refresh)
+    hass.data.setdefault(DOMAIN, {})
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up of Bakalari component."""
 
+    coord = BakalariCoordinator(hass, entry)
+    await coord.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {"coordinator": coord}
+
+    # Device Registry: one device per child
+    devreg = dr.async_get(hass)
+    for child in coord.child_list:
+        devreg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={device_ident(entry.entry_id, child.key)},
+            manufacturer=MANUFACTURER,
+            name=f"Bakaláři – {child.display_name}",
+            model=MODEL,
+            sw_version=coord.api_version,
+        )
+
+    # Services
+    async def _srv_mark_seen(call) -> None:
+        await coord.async_mark_seen(call.data["mark_id"], call.data.get("child_key"))
+        await coord.async_request_refresh()
+
+    async def _srv_refresh(call) -> None:  # noqa: ARG001
+        await coord.async_request_refresh()
+
+    hass.services.async_register(DOMAIN, "mark_as_seen", _srv_mark_seen)
+    hass.services.async_register(DOMAIN, "refresh", _srv_refresh)
+
+    # WebSocket API
+    @websocket_api.websocket_command(
+        {
+            vol.Required("type"): f"{DOMAIN}/get_marks",
+            vol.Required("config_entry_id"): str,
+            vol.Optional("child_key"): str,
+            vol.Optional("limit", default=50): int,
+        }
+    )
+    @websocket_api.async_response
+    async def ws_get_marks(hass_, connection, msg):  # noqa: ANN001
+        ceid = msg["config_entry_id"]
+        limit = msg.get("limit", 50)
+        child_key = msg.get("child_key")
+        data = hass.data[DOMAIN][ceid]["coordinator"].select_marks(child_key, limit)
+        connection.send_result(msg["id"], {"items": data})
+
+    websocket_api.async_register_command(hass, ws_get_marks)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    # entry.async_on_unload(entry.add_update_listener(_options_updated))
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 
 
-# async def _options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
-#     data = hass.data[DOMAIN][entry.entry_id]
-#     coord: BakalariCoordinator = data["coordinator"]
-#     seconds = entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-#     await coord.async_set_update_interval(seconds)
-#     await coord.async_request_refresh()
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options updates by reloading the entry."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
     ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    data = hass.data[DOMAIN].pop(entry.entry_id, None)
-    if data:
-        await data["client"].async_close()
+    if ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
     return ok

--- a/custom_components/bakalari/const.py
+++ b/custom_components/bakalari/const.py
@@ -5,7 +5,11 @@ from typing import Final, NotRequired, Required, TypedDict
 DOMAIN = "bakalari"
 
 PLATFORMS = ["sensor", "calendar"]
+MANUFACTURER = "Bakaláři pro HomeAssistant"
+MODEL = "Bakaláři backend"
 
+LIB_VERSION: Final = "0.1.1"
+API_VERSION: Final = "0.5.0"
 CONF_CHILDREN: Final = "children"
 CONF_CREDENTIALS: Final = "credentials"
 CONF_USER_ID: Final = "user_id"
@@ -16,6 +20,8 @@ CONF_SERVER: Final = "server"
 CONF_NAME: Final = "name"
 CONF_SURNAME: Final = "surname"
 CONF_SCHOOL: Final = "school"
+CONF_SCAN_INTERVAL: Final = "scan_interval"
+DEFAULT_SCAN_INTERVAL: Final = 900
 
 
 class ChildRecord(TypedDict, total=False):

--- a/custom_components/bakalari/coordinator.py
+++ b/custom_components/bakalari/coordinator.py
@@ -1,0 +1,263 @@
+"""Coordinator for Bakalari API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+import logging
+from random import random
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import BakalariClient
+from .const import (
+    API_VERSION,
+    CONF_ACCESS_TOKEN,
+    CONF_CHILDREN,
+    CONF_REFRESH_TOKEN,
+    CONF_SCAN_INTERVAL,
+    CONF_SERVER,
+    CONF_USER_ID,
+    CONF_USERNAME,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LIB_VERSION,
+    ChildRecord,
+    ChildrenMap,
+)
+from .utils import ensure_children_dict, make_child_key
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class Child:
+    """Normalized child descriptor used by the coordinator."""
+
+    # Composite key, stable across servers: "<server>|<user_id>"
+    key: str
+    user_id: str
+    server: str
+    display_name: str  # e.g., "Jana Nováková (ZŠ X)"
+
+
+class BakalariCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Multi-child coordinator with per-child diff cache for new marks."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the coordinator."""
+
+        self.hass = hass
+        self.entry = entry
+
+        # Normalize children map from options and build composite-keyed map
+        children_raw: ChildrenMap = ensure_children_dict(entry.options.get(CONF_CHILDREN, {}))
+        self.children: ChildrenMap = {}
+        self._option_key_by_child_key: dict[str, str] = {}
+        child_list: list[Child] = []
+
+        for cid, cr in children_raw.items():
+            try:
+                server = (cr.get(CONF_SERVER) or "").strip()
+                user_id = (cr.get(CONF_USER_ID) or str(cid)).strip()
+                if not server or not user_id:
+                    _LOGGER.debug("Skipping child with missing server/user_id: %s", cr)
+                    continue
+
+                ck = make_child_key(server, user_id)
+                self._option_key_by_child_key[ck] = str(cid)
+
+                # Store by composite key to ensure uniqueness across servers
+                tmp_cr: ChildRecord = ChildRecord(
+                    user_id=user_id,
+                    username=str(cr.get(CONF_USERNAME, "") or ""),
+                    name=str(cr.get("name", "") or ""),
+                    surname=str(cr.get("surname", "") or ""),
+                    school=str(cr.get("school", "") or ""),
+                    server=server,
+                )
+                at = cr.get(CONF_ACCESS_TOKEN)
+                if at:
+                    tmp_cr[CONF_ACCESS_TOKEN] = at
+                rt = cr.get(CONF_REFRESH_TOKEN)
+                if rt:
+                    tmp_cr[CONF_REFRESH_TOKEN] = rt
+                self.children[ck] = tmp_cr
+
+                display_name = (
+                    f"{cr.get('name', '')} {cr.get('surname', '')} ({cr.get('school', '')})".strip()
+                )
+                child_list.append(
+                    Child(
+                        key=ck,
+                        user_id=user_id,
+                        server=server,
+                        display_name=display_name,
+                    )
+                )
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to normalize child record for id=%s: %s", cid, cr)
+
+        self.child_list: list[Child] = child_list
+
+        # Expose library/API version to entities
+        self.api_version: str = f"API: {API_VERSION} Library: ({LIB_VERSION})"
+
+        # Diff cache per child: set of (child_key, mark_id)
+        self._seen: set[tuple[str, str]] = set()
+
+        # Update interval with jitter (avoid stampedes)
+        base = int(entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL))
+        jittered = int(base * (0.9 + 0.2 * random()))
+        update_interval = timedelta(seconds=jittered)
+
+        super().__init__(
+            hass=hass,
+            logger=_LOGGER,
+            name=f"{DOMAIN} coordinator ({entry.entry_id})",
+            update_interval=update_interval,
+        )
+
+        # Per-child clients cache (BakalariClient instances)
+        self._clients: dict[str, BakalariClient] = {}
+
+        _LOGGER.debug(
+            "Coordinator initialized for entry_id=%s with %s child(ren).",
+            entry.entry_id,
+            len(self.child_list),
+        )
+
+    # ---------- Public API for services / WebSocket ----------
+
+    async def async_mark_seen(self, mark_id: str, child_key: str | None) -> None:
+        """Mark a specific mark_id as seen for a given child."""
+        ck = child_key or (self.child_list[0].key if self.child_list else "")
+        if ck and mark_id:
+            self._seen.add((ck, mark_id))
+
+    def select_marks(self, child_key: str | None, limit: int) -> list[dict[str, Any]]:
+        """Return last N marks for a child (already parsed/flattened)."""
+        ck = child_key or (self.child_list[0].key if self.child_list else "")
+        items: list[dict[str, Any]] = self.data.get("marks_by_child", {}).get(ck, [])
+        return items[: max(0, limit or 0)]
+
+    # ---------- Update lifecycle ----------
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch and prepare marks for all children."""
+        try:
+            marks_by_child: dict[str, list[dict[str, Any]]] = {}
+
+            # Sequential fetch (can be parallelized if needed)
+            for ch in self.child_list:
+                raw = await self._fetch_child(ch)
+                items = self._parse_marks(ch, raw)
+                marks_by_child[ch.key] = items
+
+        except Exception as err:  # noqa: BLE001
+            raise UpdateFailed(str(err)) from err
+        else:
+            # Diff → fire events for new marks
+            self._fire_new_events(marks_by_child)
+
+            return {
+                "marks_by_child": marks_by_child,
+                "last_sync_ok": True,
+            }
+
+    async def _fetch_child(self, child: Child) -> dict[str, Any]:
+        """Fetch raw marks payload for a specific child via BakalariClient."""
+
+        # Map composite key to original options key (usually user_id)
+        opt_key = self._option_key_by_child_key.get(child.key, child.user_id)
+
+        client = self._clients.get(child.key)
+        if client is None:
+            client = BakalariClient(self.hass, self.entry, opt_key)
+            self._clients[child.key] = client  # cache per child
+
+        subjects = await client.async_get_marks()
+        return {"subjects": subjects}
+
+    def _parse_marks(self, child: Child, raw: dict[str, Any]) -> list[dict[str, Any]]:
+        """Normalize raw marks into a flat list of dicts."""
+        subjects = raw.get("subjects") or []
+        items: list[dict[str, Any]] = []
+        try:
+            for subj in subjects:
+                subj_id = getattr(subj, "id", None)
+                subj_abbr = getattr(subj, "abbr", "") or ""
+                subj_name = getattr(subj, "name", "") or ""
+
+                # subjects.marks is a MarksRegistry (iterable)
+                marks_iter = list(subj.marks) if hasattr(subj, "marks") else []
+                for m in marks_iter:
+                    mark_id = getattr(m, "id", None)
+                    if not mark_id:
+                        continue
+                    marktext_obj = getattr(m, "marktext", None)
+                    mark_text = getattr(marktext_obj, "text", None) if marktext_obj else None
+                    points_text = getattr(m, "points_text", None)
+                    max_points = getattr(m, "max_points", None)
+                    is_points = bool(getattr(m, "is_points", False))
+                    dt_val = getattr(m, "date", None)
+                    date_iso = dt_val.isoformat() if getattr(dt_val, "isoformat", None) else None
+
+                    items.append(
+                        {
+                            "id": str(mark_id),
+                            "child_key": child.key,
+                            "user_id": child.user_id,
+                            "subject_id": str(getattr(m, "subject_id", subj_id) or ""),
+                            "subject_abbr": str(subj_abbr),
+                            "subject_name": str(subj_name),
+                            "caption": getattr(m, "caption", None),
+                            "mark_text": mark_text,
+                            "points_text": points_text,
+                            "max_points": max_points,
+                            "is_points": is_points,
+                            "date": date_iso,
+                            "is_new": bool(getattr(m, "is_new", False)),
+                            "teacher": getattr(m, "teacher", None),
+                            "theme": getattr(m, "theme", None),
+                        }
+                    )
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Failed to parse marks for child_key=%s", child.key)
+
+        # Sort by date desc if available, keep stable otherwise
+        try:
+            items.sort(key=lambda it: it.get("date") or "", reverse=True)
+        except Exception:
+            _LOGGER.debug("Failed to sort marks for child_key=%s", child.key)
+        return items
+
+    def child_by_key(self, ck: str) -> Child:
+        """Return Child object by composite key or raise KeyError."""
+        for ch in self.child_list:
+            if ch.key == ck:
+                return ch
+        raise KeyError(ck)
+
+    # ---------- Event helpers ----------
+
+    @callback
+    def _fire_new_events(self, marks_by_child: dict[str, list[dict[str, Any]]]) -> None:
+        """Emit HA events for newly observed marks."""
+        if not marks_by_child:
+            return
+
+        bus = self.hass.bus
+        for ck, items in marks_by_child.items():
+            for it in items or []:
+                mark_id = str(it.get("id") or "").strip()
+                if not mark_id:
+                    continue
+                key = (ck, mark_id)
+                if key in self._seen:
+                    continue
+                self._seen.add(key)
+                bus.async_fire("bakalari_new_mark", {**it})

--- a/custom_components/bakalari/entity.py
+++ b/custom_components/bakalari/entity.py
@@ -1,0 +1,34 @@
+"""Base entity bound to the Bakalari coordinator and a specific child."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import MANUFACTURER, MODEL
+from .coordinator import BakalariCoordinator, Child
+from .utils import device_ident
+
+
+class BakalariEntity(CoordinatorEntity[BakalariCoordinator]):
+    """Base entity bound to the Bakalari coordinator and a specific child."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: BakalariCoordinator, child: Child) -> None:
+        """Initialize the base entity."""
+        super().__init__(coordinator)
+        self.child = child
+        self._device_ident = device_ident(coordinator.entry.entry_id, child.key)
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information for the specific child."""
+        return {
+            "identifiers": {self._device_ident},
+            "manufacturer": MANUFACTURER,
+            "name": f"Bakaláři – {self.child.display_name}",
+            "model": MODEL,
+            "sw_version": self.coordinator.api_version,
+        }

--- a/custom_components/bakalari/services.yaml
+++ b/custom_components/bakalari/services.yaml
@@ -1,1 +1,23 @@
-# This file is required for Home Assistant service validation. No services are defined.
+mark_as_seen:
+  name: Mark as seen
+  description: Mark a specific mark as seen for a selected child.
+  fields:
+    mark_id:
+      name: Mark ID
+      description: Unique ID of the mark to mark as seen.
+      required: true
+      example: "abc123"
+      selector:
+        text:
+    child_key:
+      name: Child key
+      description: Composite key "<server>|<user_id>". If omitted, the first child is used.
+      required: false
+      example: "https://skola.bakalari.cz|123456"
+      selector:
+        text:
+
+refresh:
+  name: Refresh
+  description: Request an immediate data refresh from the coordinator.
+  fields: {}

--- a/custom_components/bakalari/utils.py
+++ b/custom_components/bakalari/utils.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_SURNAME,
     CONF_USER_ID,
     CONF_USERNAME,
+    DOMAIN,
     ChildRecord,
     ChildrenMap,
 )
@@ -38,8 +39,6 @@ CHILDREN_MAP_SCHEMA = vol.Schema({str: CHILD_STORAGE_SCHEMA})
 
 
 # Child helpers
-
-
 def child_from_raw(raw: dict[str, Any] | None) -> tuple[str, ChildRecord]:
     """Convert RAW data to ChildRecord."""
 
@@ -120,3 +119,20 @@ def redact_child_info(child_info: ChildRecord) -> ChildRecord:
     if CONF_REFRESH_TOKEN in redacted:
         redacted[CONF_REFRESH_TOKEN] = "***"
     return redacted
+
+
+def make_child_key(server: str, user_id: str) -> str:
+    """Create a file-system safe and readable composite key for a child.
+
+    The server must not contain the '|' character.
+    """
+    return f"{server}|{user_id}"
+
+
+def device_ident(entry_id: str, child_key: str) -> tuple[str, str]:
+    """Create a device identification tuple for Home Assistant device registry.
+
+    The entry_id and child_key must not contain the ':' character.
+    """
+    # identification tuple for HA device registry
+    return (DOMAIN, f"{entry_id}:{child_key}")

--- a/script/validate_version.py
+++ b/script/validate_version.py
@@ -23,10 +23,12 @@ FILES = {
             r'"async-bakalari-api==([0-9][^"]+)"',
         ),
         (ROOT / "README.md", r"async-bakalari-api==([0-9][^\s#]+)\`"),
+        (ROOT / "custom_components/bakalari/const.py", r"API_VERSION: Final = \"([0-9][^\s#]+)\""),
     ],
     "library": [
         (ROOT / "custom_components/bakalari/manifest.json", r"\"version\":\s*\"([0-9][^\s#]+)\""),
         (ROOT / "pyproject.toml", r"version = \"([0-9][^\s#]+)\""),
+        (ROOT / "custom_components/bakalari/const.py", r"LIB_VERSION: Final = \"([0-9][^\s#]+)\""),
     ],
 }
 


### PR DESCRIPTION
Adds device registry support for Bakalari component, creating a device per child account and exposing library versions.

Introduces new services for marking notifications as read and triggering data refresh.

Provides WebSocket API for fetching marks, and updates version handling.

Fixes #46 
