### PR TITLE
Mark messages as read in coordinator, improve logging

### DIFF
--- a/custom_components/bakalari/__init__.py
+++ b/custom_components/bakalari/__init__.py
@@ -41,7 +41,7 @@ class CustomFormatter(logging.Formatter):
     cyan = "\u001b[36m"
     white = "\u001b[37m"
 
-    _format = f"%(asctime)s - %(levelname)s [%(name)s]\n{reset}Message: %(message)s)"
+    _format = f"%(asctime)s - %(levelname)s [%(name)s] %(funcName)s{reset}\nMessage: %(message)s)"
     dateformat = "%d/%m/%Y %H:%M:%S"
 
     FORMATS = {
@@ -62,6 +62,10 @@ class CustomFormatter(logging.Formatter):
 
 async def async_setup(hass: HomeAssistant, config) -> bool:
     """Set up the Bakalari component."""
+
+    _dev_console_handler_for(
+        logging.getLogger("custom_components.bakalari"), CustomFormatter()
+    )
     hass.data.setdefault(DOMAIN, {})
     return True
 
@@ -73,11 +77,19 @@ def _dev_console_handler_for(
     # pokud už nějaké handlery existují (na loggeru NEBO u předků), nedělej nic
     # if logger.hasHandlers():
     #     return
+    existing = [h for h in logger.handlers if getattr(h, "_bakalari_dev", False)]
+    if existing:
+        if formatter is not None:
+            existing[0].setFormatter(formatter)
+        logger.propagate = False
+        configure_logging(logger.getEffectiveLevel())
+        return
 
     h = logging.StreamHandler()  # default: stderr
     if formatter is None:
         formatter = logging.Formatter("[%(levelname)s] %(name)s: %(message)s")
     h.setFormatter(formatter)
+    h._bakalari_dev = True  # pyright: ignore[reportAttributeAccessIssue]
 
     # level nech na loggeru; handler level nenech NOTSET explicitně – zbytečné
     logger.addHandler(h)
@@ -120,7 +132,7 @@ def _register_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         await coord.async_mark_message_seen(
             call.data["message_id"], call.data.get("child_key")
         )
-        await coord.async_request_refresh()
+        await coord.async_refresh()
 
     async def _srv_refresh_messages(call) -> None:  # noqa: ARG001
         await hass.data[DOMAIN][entry.entry_id]["messages"].async_refresh()
@@ -207,9 +219,6 @@ def _register_websocket(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up of Bakalari component."""
-    _dev_console_handler_for(
-        logging.getLogger("custom_components.bakalari"), CustomFormatter()
-    )
 
     children = ChildrenIndex.from_entry(entry)
 

--- a/custom_components/bakalari/api.py
+++ b/custom_components/bakalari/api.py
@@ -65,11 +65,12 @@ class BakalariClient:
         self._save_lock = asyncio.Lock()
         self._last_tokens: tuple[str, str] | None = None
 
-        _LOGGER.info(
+        _LOGGER.debug(
             "[class=%s module=%s] Created BakalariClient instance for child_id=%s",
             self.__class__.__name__,
             __name__,
             self.child_id,
+            stacklevel=2,
         )
 
     def api_call(
@@ -214,12 +215,14 @@ class BakalariClient:
                     self.lib = Bakalari(
                         server=server, credentials=cred, session=session
                     )
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "[class=%s module=%s] Bakalari library instance created for child_id=%s With parameters: %s",
                         self.__class__.__name__,
                         __name__,
                         self.child_id,
                         redact_child_info(child),
+                        stacklevel=2,
+                        stack_info=True,
                     )
 
         self._last_tokens = self._snapshot_tokens()
@@ -519,3 +522,17 @@ class BakalariClient:
 
         marks = Marks(lib)
         await marks.async_sign_marks(subjects)
+
+    @api_call(label="Mark message as read", default=None)
+    async def message_mark_as_read(self, lib, mid):
+        """Mark message as read.
+
+        Call API clients mark message as read function.
+        """
+        _LOGGER.debug(
+            "[class=%s module=%s] Called mark message as read endpoint.",
+            self.__class__.__name__,
+            __name__,
+        )
+        komens: Komens = Komens(lib)
+        await komens.message_mark_read(mid)

--- a/custom_components/bakalari/api.py
+++ b/custom_components/bakalari/api.py
@@ -524,7 +524,7 @@ class BakalariClient:
         await marks.async_sign_marks(subjects)
 
     @api_call(label="Mark message as read", default=None)
-    async def message_mark_as_read(self, lib, mid):
+    async def message_mark_as_read(self, lib, mid: str):
         """Mark message as read.
 
         Call API clients mark message as read function.

--- a/custom_components/bakalari/coordinator_messages.py
+++ b/custom_components/bakalari/coordinator_messages.py
@@ -108,6 +108,9 @@ class BakalariMessagesCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if ck and message_id:
             self._seen_msgs.add((ck, message_id))
 
+        messages = self._clients[ck]
+        await messages.message_mark_as_read(message_id)
+
     # -------- Update lifecycle --------
 
     async def _async_update_data(self) -> dict[str, Any]:


### PR DESCRIPTION
- Add message_mark_as_read API call 
-  Call message_mark_as_read in coordinator on message seen 
- Prevent duplicate console handlers and update handler config 
- Replace deprecated async_request_refresh with async_refresh
- Enhance log format with function names 
- Use debug level for client creation logs 

