### PR TITLE
Bump version to 1.6.3, updated async_bakalari_api to 0.10.2 (#100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           pip install pytest pytest-asyncio pytest-homeassistant-custom-component ruff basedpyright
           pip install -e .
           # HA runtime pro testy (minimální):
-          pip install homeassistant==2025.9.4
-          pip install async-bakalari-api==0.10.0
+          pip install homeassistant==2026.2.3
+          pip install async-bakalari-api==0.10.2
       - name: Ruff (lint)
         run: ruff check .
       - name: Ruff (format)

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ RUFF   := $(PYTHON) -m ruff
 PYTEST := $(PYTHON) -m pytest
 
 # Verze / cesty
-HA_VERSION := 2025.9.4
-BAKALARI_VERSION := 0.10.0
+HA_VERSION := 2026.2.3
+BAKALARI_VERSION := 0.10.2
 HA_CONFIG := ./config
 COMPONENT_PATH := custom_components/bakalari
 
@@ -19,7 +19,7 @@ COMPONENT_PATH := custom_components/bakalari
 HASSFEST_CORE_DIR := .ha-core
 HASSFEST_REPO := https://github.com/home-assistant/core
 # ev. $(HA_VERSION)
-HASSFEST_REF ?= dev
+HASSFEST_REF ?= $(HA_VERSION)
 
 # Prostředí
 export VIRTUAL_ENV_DISABLE_PROMPT=1
@@ -111,15 +111,17 @@ hassfest-setup:
 	@if ! command -v git >/dev/null 2>&1; then \
 	  echo "❌ git není dostupný v PATH"; exit 1; \
 	fi
-	@if [ ! -d "$(HASSFEST_CORE_DIR)/.git" ]; then \
+	@set -euo pipefail; \
+	if [ ! -d "$(HASSFEST_CORE_DIR)/.git" ]; then \
 	  echo "📥 Cloning Home Assistant core ($(HASSFEST_REF))..."; \
 	  git clone --depth 1 --branch $(HASSFEST_REF) $(HASSFEST_REPO) $(HASSFEST_CORE_DIR); \
 	else \
 	  echo "🔄 Updating Home Assistant core ($(HASSFEST_REF))..."; \
 	  git -C $(HASSFEST_CORE_DIR) fetch --depth 1 origin $(HASSFEST_REF); \
-	  git -C $(HASSFEST_CORE_DIR) checkout -q $(HASSFEST_REF) || true; \
-	  git -C $(HASSFEST_CORE_DIR) reset --hard -q origin/$(HASSFEST_REF) || true; \
-	fi
+	  git -C $(HASSFEST_CORE_DIR) reset --hard FETCH_HEAD; \
+	  git -C $(HASSFEST_CORE_DIR) clean -fdx; \
+	fi; \
+	echo "✅ .ha-core @ $$(git -C $(HASSFEST_CORE_DIR) rev-parse --short HEAD)"
 
 hassfest-local: hassfest-setup
 	PYTHONPATH=$(HASSFEST_CORE_DIR) $(PYTHON) -m script.hassfest --integration-path $(COMPONENT_PATH)

--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ Doporučení:
 
 ## Požadavky
 
-- Home Assistant `2025.9.4+`
-- PyPI: `async-bakalari-api==0.10.0`
+- Home Assistant `2026.2.3+`
+- PyPI: `async-bakalari-api==0.10.2`
 
 ## Licence
 

--- a/bump-bakalari.toml
+++ b/bump-bakalari.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "0.10.0"
+current_version = "0.10.2"
 commit = false
 tag = false
 

--- a/bump-ha.toml
+++ b/bump-ha.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "2025.9.4"
+current_version = "2026.2.3"
 commit = false
 tag = false
 

--- a/custom_components/bakalari/const.py
+++ b/custom_components/bakalari/const.py
@@ -9,7 +9,7 @@ MANUFACTURER = "Bakaláři pro HomeAssistant"
 MODEL = "Bakaláři backend"
 
 LIB_VERSION: Final = "1.6.2"
-API_VERSION: Final = "0.10.0"
+API_VERSION: Final = "0.10.2"
 SW_VERSION: Final = f"API: {API_VERSION} Library: {LIB_VERSION}"
 CONF_CHILDREN: Final = "children"
 CONF_CREDENTIALS: Final = "credentials"

--- a/custom_components/bakalari/const.py
+++ b/custom_components/bakalari/const.py
@@ -8,7 +8,7 @@ PLATFORMS = ["sensor", "calendar"]
 MANUFACTURER = "Bakaláři pro HomeAssistant"
 MODEL = "Bakaláři backend"
 
-LIB_VERSION: Final = "1.6.2"
+LIB_VERSION: Final = "1.6.3"
 API_VERSION: Final = "0.10.2"
 SW_VERSION: Final = f"API: {API_VERSION} Library: {LIB_VERSION}"
 CONF_CHILDREN: Final = "children"

--- a/custom_components/bakalari/manifest.json
+++ b/custom_components/bakalari/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "async-bakalari-api==0.10.2"
   ],
-  "version": "1.6.2"
+  "version": "1.6.3"
 }

--- a/custom_components/bakalari/manifest.json
+++ b/custom_components/bakalari/manifest.json
@@ -14,7 +14,7 @@
     "async_bakalari_api"
   ],
   "requirements": [
-    "async-bakalari-api==0.10.0"
+    "async-bakalari-api==0.10.2"
   ],
   "version": "1.6.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -3,6 +3,6 @@
   "country": "CZ",
   "filename": "bakalari-ha.zip",
   "render_readme": true,
-  "homeassistant": "2025.9.4",
+  "homeassistant": "2026.2.3",
   "zip_release": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bakalari-ha"
-version = "1.6.2"
+version = "1.6.3"
 description = "Home Assistant custom integration for Bakaláři API endpoints."
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Bump Home Assistant and async-bakalari-api

Update references in CI, manifest, hacs.json, README and bump config. Improve hassfest setup in the Makefile: default HASSFEST_REF to HA_VERSION, enable strict shell options, reset to FETCH_HEAD, clean untracked files, and echo the .ha-core commit.

